### PR TITLE
【依頼】商品一覧表示機能の確認

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @products = Product.all
+    @products = Product.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -123,14 +123,14 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_product_path, class: "subtitle" %>
     <ul class='item-lists'>
-
+     <% @products.each do |product| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= product.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= product.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,10 +157,10 @@
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
+      <%# <li class='list'>
         <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
+       <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+       <%# <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！
           </h3>
@@ -168,14 +168,15 @@
             <span>99999999円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+             <%# <span class='star-count'>0</span>
             </div>
           </div>
         </div>
         <% end %>
-      </li>
+      <%#</li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -132,7 +132,7 @@
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -131,11 +131,11 @@
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れていればsold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
           <%# <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れていればsold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
 
         </div>
         <div class='item-info'>
@@ -154,11 +154,11 @@
       </li>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <li class='list'>
+      <% if @products.length == 0 %>
+       <li class='list'>
         <%= link_to '#' do %>
-       <%# <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-       <%# <div class='item-info'>
+       <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
+        <div class='item-info'>
           <h3 class='item-name'>
             商品を出品してね！
           </h3>
@@ -166,15 +166,15 @@
             <span>99999999円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
-             <%# <span class='star-count'>0</span>
+              <span class='star-count'>0</span>
             </div>
           </div>
         </div>
         <% end %>
-      <%#</li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+       </li>
       <% end %>
+      <%# /商品がない場合のダミー %>
+     <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -126,7 +126,6 @@
     <%= link_to '新規投稿商品', new_product_path, class: "subtitle" %>
     <ul class='item-lists'>
      <% @products.each do |product| %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -153,7 +152,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
#What 
商品一覧表示機能を実装 
#Why
出品された商品を一覧で表示するため

＊『sold out』の文字表示機能は購入機能実装後に追加

Gyazo_GIF_URL
商品出品後の一覧表示成功の動画
https://gyazo.com/6e8a1656da4fb1616daa93e9d13befe7
ログアウト状態でも一覧表示成功の動画
https://gyazo.com/5834e82701ad3912a19fc97c7451e137