### PR TITLE
【依頼】商品詳細表示機能の確認

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,6 +19,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   def edit

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,7 +2,7 @@ class ProductsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @products = Product.all.order("created_at DESC")
+    @products = Product.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,11 +127,11 @@
     <ul class='item-lists'>
      <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
 
-          <%# //商品が売れていればsold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
+          <%# 商品が売れていればsold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
           <%# <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -101,7 +101,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,30 +4,30 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
+      <%= image_tag @product.image, class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
+      <%#<div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# //商品が売れている場合は、sold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @product.price %>
       </span>
       <span class="item-postage">
-        (税込) 送料込み
+        <%= @product.shopping_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+    <%= link_to '商品の編集', edit_product_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <%= link_to '削除', product_path, method: :delete, class:'item-destroy' %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shopping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.shopping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -10,8 +10,10 @@
       <%= image_tag @product.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
       <%#<div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+       <%# unless @product_id.present? %>
+        <%#<span>Sold Out!!</span>
+       <%# end %>
+       <%#</div>
       <%# //商品が売れている場合は、sold outを表示しましょう %><%# 商品購入機能実装後に実装 %>
     </div>
     <div class="item-price-box">
@@ -23,18 +25,15 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+ <% if user_signed_in? %>
+　 <% if current_user == @product.user %>
     <%= link_to '商品の編集', edit_product_path, method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', product_path, method: :delete, class:'item-destroy' %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+   <% else @product_id.present? %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+   <% end %>
+ <% end %>
 
     <div class="item-explain-box">
       <span><%= @product.description %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:index, :new, :create]
+  resources :products
 end


### PR DESCRIPTION
#What
 商品詳細表示機能を実装
 #Why
出品した  商品の詳細表示のため

＊『sold out』の文字表示機能は購入機能実装後に追加

Gyazo_GIF_URL
ログイン状態の出品者のみ、「編集・削除ボタン」が表示されることが成功する動画
https://gyazo.com/26ee1f7065469a47be9a534e78a9704b
ログイン状態の出品者以外のユーザーのみ、「購入画面に進むボタン」が表示されることが成功する動画
https://gyazo.com/a31cc751cd9ab46257f142af7be44eea
ログアウト状態のユーザーには、「編集・削除・購入画面に進むボタン」が表示されないことが成功する動画
https://gyazo.com/abf7de6aec56a83312f18c6acec749d9
ログアウト状態のユーザーでも、商品詳細表示ページを閲覧できることが成功する動画
https://gyazo.com/3d4c1877c318174f003d58eb2a6c91a3
商品出品時に登録した情報が見られるようになっていることが成功する動画
https://gyazo.com/098786df3b43ddae9c42f4bc6b1777e2